### PR TITLE
[feature/jp-gitactions] two blank template pipelines

### DIFF
--- a/.github/workflows/application-configuration-update.yml
+++ b/.github/workflows/application-configuration-update.yml
@@ -1,0 +1,24 @@
+name: application-configuration-update
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Select environment'
+        required: true
+        default: 'Dev'
+        type: choice
+        options:
+          - Dev
+        # - Test
+        # - Prod
+        # - Custom
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+      - name: Run a one-line script
+        run: echo "Hello, world!"

--- a/.github/workflows/environment-configuration-update.yml
+++ b/.github/workflows/environment-configuration-update.yml
@@ -1,0 +1,24 @@
+name: environment-configuration-update
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Select environment'
+        required: true
+        default: 'Dev'
+        type: choice
+        options:
+          - Dev
+        # - Test
+        # - Prod
+        # - Custom
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+      - name: Run a one-line script
+        run: echo "Hello, world!"


### PR DESCRIPTION
Added two blank "template pipelines" that is necessary for my pipeline to be initialized in my branch (`feature/jp-gitactions`)
```
.github/workflows/application-configuration-update.yml
.github/workflows/environment-configuration-update.yml
```
content:
```
name: application-configuration-update

on:
  workflow_dispatch:
    inputs:
      environment:
        description: 'Select environment'
        required: true
        default: 'Dev'
        type: choice
        options:
          - Dev
        # - Test
        # - Prod
        # - Custom

jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout code
        uses: actions/checkout@v4.2.2
      - name: Run a one-line script
        run: echo "Hello, world!"
```
